### PR TITLE
Fixes

### DIFF
--- a/crystal/read.py
+++ b/crystal/read.py
@@ -261,6 +261,7 @@ def castep(file):
 
 def crystal(file='fort.34'):
     """ Reads CRYSTAL's external format. """
+    from six import next
     from numpy import array, abs, zeros, any, dot
     from numpy.linalg import inv
     from ..crystal import which_site
@@ -284,7 +285,7 @@ def crystal(file='fort.34'):
         dimensionality, centering, type = [int(u) for u in line.split()[:3]]
     # read cell
     try:
-        cell = array([file.next().split()[:3] for i in range(3)],
+        cell = array([next(file).split()[:3] for i in range(3)],
                      dtype='float64').T
     except StopIteration:
         raise error.IOError('Premature end of stream.')
@@ -298,7 +299,7 @@ def crystal(file='fort.34'):
         raise error.IOError('Premature end of stream.')
     for i in range(N):
         try:
-            op = array([file.next().split()[:3] for j in range(4)],
+            op = array([next(file).split()[:3] for j in range(4)],
                        dtype='float64')
         except StopIteration:
             raise error.IOError('Premature end of stream.')
@@ -315,7 +316,7 @@ def crystal(file='fort.34'):
 
     for i in range(N):
         try:
-            line = file.next().split()
+            line = next(file).split()
         except StopIteration:
             raise error.IOError('Premature end of stream.')
         else:

--- a/vasp/extract/base.py
+++ b/vasp/extract/base.py
@@ -173,6 +173,7 @@ class ExtractBase(object):
     @property
     def initial_structure(self):
         """ Structure at start of calculations. """
+        from six import next
         from re import compile
         from numpy import array, dot
         from numpy.linalg import inv
@@ -187,7 +188,7 @@ class ExtractBase(object):
                     break
             data = []
             for i in range(3):
-                data.append(file.next().split())
+                data.append(next(file).split())
             try:
                 for i in range(3):
                     result.cell[:, i] = array(data[i][:3], dtype='float64')

--- a/vasp/extract/base.py
+++ b/vasp/extract/base.py
@@ -173,6 +173,7 @@ class ExtractBase(object):
     @property
     def initial_structure(self):
         """ Structure at start of calculations. """
+        from re import compile
         from numpy import array, dot
         from numpy.linalg import inv
         from ...crystal import Structure


### PR DESCRIPTION
- missing `compile`
- python 2 to 3: `file.next()` to `next(file)`. Using `six` for this, so we remain compatible with python2.