### PR TITLE
conda+pip uses old deployment version for osx

### DIFF
--- a/espresso/misc.py
+++ b/espresso/misc.py
@@ -25,6 +25,7 @@ __docformat__ = "restructuredtext en"
 __all__ = ['write_f90namelist', 'write_pwscf_input']
 from ..espresso import logger
 
+
 def write_f90namelist(f90namelist, stream=None):
     """ Writes namelist to file or string, or stream
 
@@ -50,15 +51,7 @@ def write_f90namelist(f90namelist, stream=None):
         with open(path, 'w') as file:
             write_f90namelist(f90namelist, file)
         return
-
-    for key, value in f90namelist.items():
-        if isinstance(value, list):
-            for g_vars in value:
-                f90namelist.write_nmlgrp(key, g_vars, stream)
-        elif isinstance(value, F90Namelist):
-            f90namelist.write_nmlgrp(key, value, stream)
-        else:
-            raise RuntimeError("Can only write namelists that consist of namelists")
+    f90namelist.write(stream)
 
 
 def write_pwscf_input(f90namelist, cards, stream=None):
@@ -74,8 +67,10 @@ def write_pwscf_input(f90namelist, cards, stream=None):
     from ..misc import local_path
     from six import StringIO
 
-    card_order = ['atomic_species', 'atomic_positions', 'k_points', 'cell_parameters',
-                  'constraints', 'occupations', 'atomic_forces']
+    card_order = [
+        'atomic_species', 'atomic_positions', 'k_points', 'cell_parameters',
+        'constraints', 'occupations', 'atomic_forces'
+    ]
     """ Write cards in this order """
     namelist_order = ['control', 'system', 'electrons', 'ions', 'cell']
     """ Order of the namelists """
@@ -97,10 +92,10 @@ def write_pwscf_input(f90namelist, cards, stream=None):
         return -1 if list_.count(item) == 0 else list_.index(item)
 
     # reorders namelists
-    f90namelist = F90Namelist(sorted(
-        f90namelist.items(),
-        key=lambda x: key_order(x[0], namelist_order)
-    ))
+    f90namelist = F90Namelist(
+        sorted(
+            f90namelist.items(),
+            key=lambda x: key_order(x[0], namelist_order)))
     # reorders cards
     cards.sort(key=lambda x: key_order(x.name, card_order))
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ class Build(dBuild):
             cmake_cache_line('PYTHON_EXECUTABLE', executable, 'PATH'),
             cmake_cache_line('PYTHON_BINARY_DIR', package_dir, 'PATH'),
             cmake_cache_line('CMAKE_BUILD_TYPE', 'Release', 'STRING'),
+            cmake_cache_line('CMAKE_OSX_DEPLOYMENT_TARGET', '10.9', 'STRING'),
             '\n',
         ]
 
@@ -59,10 +60,8 @@ class Build(dBuild):
         current_dir = getcwd()
         mkpath(build_dir)
         command_line = self.configure_cmdl(join(build_dir, 'Variables.cmake'))
-        log.info(
-            "CMake: configuring with variables in %s "
-            % join(build_dir, 'Variables.cmake')
-        )
+        log.info("CMake: configuring with variables in %s " % join(
+            build_dir, 'Variables.cmake'))
         cmake = cmake_executable()
 
         try:
@@ -102,7 +101,6 @@ class Build(dBuild):
 
 
 class Install(dInstall):
-
     def run(self):
         from distutils import log
         self.distribution.run_command('build')
@@ -113,10 +111,7 @@ class Install(dInstall):
         log.info("CMake: Installing package to %s" % pkg)
         try:
             chdir(build_dir)
-            self.spawn([cmake,
-                        '-DPYTHON_PKG_DIR=\'%s\'' % pkg,
-                        '..'
-                        ])
+            self.spawn([cmake, '-DPYTHON_PKG_DIR=\'%s\'' % pkg, '..'])
             self.spawn([cmake, '--build', '.', '--target', 'install'])
         finally:
             chdir(current_cwd)
@@ -131,15 +126,14 @@ class Install(dInstall):
 
 
 class BuildExt(dBuildExt):
-
     def __init__(self, *args, **kwargs):
         dBuildExt.__init__(self, *args, **kwargs)
 
-    def run(self): pass
+    def run(self):
+        pass
 
 
 class BuildDistEgg(dBuildDistEgg):
-
     def __init__(self, *args, **kwargs):
         dBuildDistEgg.__init__(self, *args, **kwargs)
 
@@ -155,7 +149,6 @@ class BuildDistEgg(dBuildDistEgg):
 
 
 class EggInfo(dEggInfo):
-
     def __init__(self, *args, **kwargs):
         dEggInfo.__init__(self, *args, **kwargs)
 
@@ -185,7 +178,6 @@ class EggInfo(dEggInfo):
 
 
 class Develop(dDevelop):
-
     def run(self):
         if not self.uninstall:
             build = self.distribution.get_command_obj("build")
@@ -194,7 +186,6 @@ class Develop(dDevelop):
 
 
 class SDist(dSDist):
-
     def __init__(self, *args, **kwargs):
         dSDist.__init__(self, *args, **kwargs)
 
@@ -209,58 +200,58 @@ class SDist(dSDist):
         finally:
             dist.ext_modules, dist.ext_package = old_values[:2]
             dist.packages, dist.package_dir = old_values[2:]
+
+
 try:
     cwd = getcwd()
     chdir(source_dir)
     setup(
         name="pylada",
         version="1.0",
-
-        install_requires=['numpy', 'scipy', 'pytest', 'quantities', 'cython', 'mpi4py', 'six',
-                          'traitlets', 'f90nml', 'pytest-bdd'],
+        install_requires=[
+            'numpy', 'scipy', 'pytest', 'quantities', 'cython', 'mpi4py',
+            'six', 'traitlets', 'f90nml', 'pytest-bdd'
+        ],
         platforms=['GNU/Linux', 'Unix', 'Mac OS-X'],
-
         zip_safe=False,
         cmdclass={
-            'build': Build, 'install': Install,
-            'build_ext': BuildExt, 'bdist_egg': BuildDistEgg,
-            'egg_info': EggInfo, 'develop': Develop
+            'build': Build,
+            'install': Install,
+            'build_ext': BuildExt,
+            'bdist_egg': BuildDistEgg,
+            'egg_info': EggInfo,
+            'develop': Develop
         },
-
         author=["Peter Graf"],
         author_email="peter.graf@nrel.gov",
         description="Productivity environment for Density Functional Theory",
         license="GPL-2",
         url="https://github.com/pylada/pylada",
-        ext_modules=[Extension(u, []) for u in [
-            'pylada.crystal.cutilities',
-            'pylada.crystal.defects.cutilities',
-            'pylada.decorations._cutilities',
-            'pylada.ewald',
-        ]],
+        ext_modules=[
+            Extension(u, []) for u in [
+                'pylada.crystal.cutilities',
+                'pylada.crystal.defects.cutilities',
+                'pylada.decorations._cutilities',
+                'pylada.ewald',
+            ]
+        ],
         ext_package='pylada',
         packages=[
-            'pylada',
-            'pylada.physics',
-            'pylada.jobfolder', 'pylada.jobfolder.tests',
-            'pylada.crystal', 'pylada.crystal.tests',
-            'pylada.crystal.defects',
-            'pylada.decorations', 'pylada.decorations.tests',
-            'pylada.misc',
-            'pylada.config',
+            'pylada', 'pylada.physics', 'pylada.jobfolder',
+            'pylada.jobfolder.tests', 'pylada.crystal', 'pylada.crystal.tests',
+            'pylada.crystal.defects', 'pylada.decorations',
+            'pylada.decorations.tests', 'pylada.misc', 'pylada.config',
             'pylada.ipython', 'pylada.ipython.tests', 'pylada.ipython.launch',
-            'pylada.ewald.tests',
-            'pylada.process', 'pylada.process.tests',
+            'pylada.ewald.tests', 'pylada.process', 'pylada.process.tests',
             'pylada.vasp', 'pylada.vasp.tests', 'pylada.vasp.extract',
-            'pylada.vasp.extract.tests', 'pylada.vasp.nlep', 'pylada.vasp.incar',
-            'pylada.vasp.incar.tests',
-            'pylada.tools', 'pylada.tools.tests', 'pylada.tools.input',
-            'pylada.tools.input.tests',
-            'pylada.espresso', 'pylada.espresso.tests'
+            'pylada.vasp.extract.tests', 'pylada.vasp.nlep',
+            'pylada.vasp.incar', 'pylada.vasp.incar.tests', 'pylada.tools',
+            'pylada.tools.tests', 'pylada.tools.input',
+            'pylada.tools.input.tests', 'pylada.espresso',
+            'pylada.espresso.tests'
         ],
         package_dir={'': str(basename(package_dir))},
         include_package_data=True,
-
         keywords="Physics",
         classifiers=[
             'Development Status :: 0 - Beta',
@@ -274,7 +265,6 @@ try:
             'Topic :: Software Development :: Libraries :: Python Modules',
             'Topic :: Software Development :: Libraries :: Application Frameworks',
         ],
-        long_description=long_description
-    )
+        long_description=long_description)
 finally:
     chdir(cwd)

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ try:
         version="1.0",
         install_requires=[
             'numpy', 'scipy', 'pytest', 'quantities', 'cython', 'mpi4py',
-            'six', 'traitlets', 'f90nml', 'pytest-bdd'
+            'six', 'traitlets', 'f90nml>=1.0', 'pytest-bdd'
         ],
         platforms=['GNU/Linux', 'Unix', 'Mac OS-X'],
         zip_safe=False,

--- a/vasp/tests/test_encut.py
+++ b/vasp/tests/test_encut.py
@@ -48,37 +48,61 @@ def test_encut():
 
     a.encut = 1e0
     assert abs(a.encut - 1e0) < 1e-8
-    assert abs(float(o.output_map(structure=structure, vasp=a)['encut']) - 245.345) < 1e-8
-    assert abs(float(eval(repr(o), d).output_map(
-        structure=structure, vasp=a)['encut']) - 245.345) < 1e-8
-    assert abs(float(loads(dumps(o)).output_map(
-        structure=structure, vasp=a)['encut']) - 245.345) < 1e-8
+    assert abs(
+        float(o.output_map(structure=structure, vasp=a)['encut']) - 245.345
+    ) < 1e-8
+    assert abs(
+        float(
+            eval(repr(o), d).output_map(structure=structure, vasp=a)['encut'])
+        - 245.345) < 1e-8
+    assert abs(
+        float(
+            loads(dumps(o)).output_map(structure=structure, vasp=a)['encut']) -
+        245.345) < 1e-8
     assert abs(eval(repr(o), d).value - 1.0) < 1e-8
     assert abs(loads(dumps(o)).value - 1.0) < 1e-8
     a.encut = 0.8
     assert abs(a.encut - 0.8) < 1e-8
-    assert abs(float(o.output_map(structure=structure, vasp=a)['encut']) - 245.345 * 0.8) < 1e-8
-    assert abs(float(eval(repr(o), d).output_map(
-        structure=structure, vasp=a)['encut']) - 245.345 * 0.8) < 1e-8
-    assert abs(float(loads(dumps(o)).output_map(
-        structure=structure, vasp=a)['encut']) - 245.345 * 0.8) < 1e-8
+    assert abs(
+        float(o.output_map(structure=structure, vasp=a)['encut']) -
+        245.345 * 0.8) < 1e-8
+    assert abs(
+        float(
+            eval(repr(o), d).output_map(structure=structure, vasp=a)['encut'])
+        - 245.345 * 0.8) < 1e-8
+    assert abs(
+        float(
+            loads(dumps(o)).output_map(structure=structure, vasp=a)['encut']) -
+        245.345 * 0.8) < 1e-8
     assert abs(eval(repr(o), d).value - 0.8) < 1e-8
     assert abs(loads(dumps(o)).value - 0.8) < 1e-8
     a.encut = 200
     assert abs(a.encut - 200) < 1e-8
-    assert abs(float(o.output_map(structure=structure, vasp=a)['encut']) - 200) < 1e-8
-    assert abs(float(eval(repr(o), d).output_map(
-        structure=structure, vasp=a)['encut']) - 200) < 1e-8
-    assert abs(float(loads(dumps(o)).output_map(structure=structure, vasp=a)['encut']) - 200) < 1e-8
+    assert abs(
+        float(o.output_map(structure=structure, vasp=a)['encut']) - 200) < 1e-8
+    assert abs(
+        float(
+            eval(repr(o), d).output_map(structure=structure, vasp=a)['encut'])
+        - 200) < 1e-8
+    assert abs(
+        float(
+            loads(dumps(o)).output_map(structure=structure, vasp=a)['encut']) -
+        200) < 1e-8
     assert abs(eval(repr(o), d).value - 200) < 1e-8
     assert abs(loads(dumps(o)).value - 200) < 1e-8
     a.encut = 200 * eV
     assert abs(a.encut - 200 * eV) < 1e-8
     assert a.encut.units == eV
-    assert abs(float(o.output_map(structure=structure, vasp=a)['encut']) - 200) < 1e-8
-    assert abs(float(eval(repr(o), d).output_map(
-        structure=structure, vasp=a)['encut']) - 200) < 1e-8
-    assert abs(float(loads(dumps(o)).output_map(structure=structure, vasp=a)['encut']) - 200) < 1e-8
+    assert abs(
+        float(o.output_map(structure=structure, vasp=a)['encut']) - 200) < 1e-8
+    assert abs(
+        float(
+            eval(repr(o), d).output_map(structure=structure, vasp=a)['encut'])
+        - 200) < 1e-8
+    assert abs(
+        float(
+            loads(dumps(o)).output_map(structure=structure, vasp=a)['encut']) -
+        200) < 1e-8
     assert abs(eval(repr(o), d).value - 200 * eV) < 1e-8
     assert abs(loads(dumps(o)).value - 200 * eV) < 1e-8
     assert eval(repr(o), d).value.units == eV
@@ -86,10 +110,16 @@ def test_encut():
     a.encut = (200 * eV).rescale(hartree)
     assert a.encut.units == hartree
     assert abs(a.encut - 200 * eV) < 1e-8
-    assert abs(float(o.output_map(structure=structure, vasp=a)['encut']) - 200) < 1e-8
-    assert abs(float(eval(repr(o), d).output_map(
-        structure=structure, vasp=a)['encut']) - 200) < 1e-8
-    assert abs(float(loads(dumps(o)).output_map(structure=structure, vasp=a)['encut']) - 200) < 1e-8
+    assert abs(
+        float(o.output_map(structure=structure, vasp=a)['encut']) - 200) < 1e-8
+    assert abs(
+        float(
+            eval(repr(o), d).output_map(structure=structure, vasp=a)['encut'])
+        - 200) < 1e-7
+    assert abs(
+        float(
+            loads(dumps(o)).output_map(structure=structure, vasp=a)['encut']) -
+        200) < 1e-8
     assert abs(eval(repr(o), d).value - 200 * eV) < 1e-8
     assert abs(loads(dumps(o)).value - 200 * eV) < 1e-8
     assert eval(repr(o), d).value.units == hartree
@@ -107,15 +137,22 @@ def test_encut():
     a.encutgw = (200 * eV).rescale(hartree)
     assert a.encutgw.units == hartree
     assert abs(a.encutgw - 200 * eV) < 1e-8
-    assert abs(float(o.output_map(structure=structure, vasp=a)['encutgw']) - 200) < 1e-8
-    assert abs(float(eval(repr(o), d).output_map(
-        structure=structure, vasp=a)['encutgw']) - 200) < 1e-8
-    assert abs(float(loads(dumps(o)).output_map(
-        structure=structure, vasp=a)['encutgw']) - 200) < 1e-8
-    assert abs(eval(repr(o), d).value - 200 * eV) < 1e-8
+    assert abs(
+        float(o.output_map(structure=structure, vasp=a)['encutgw']) - 200
+    ) < 1e-8
+    assert abs(
+        float(
+            eval(repr(o), d).output_map(structure=structure, vasp=a)
+            ['encutgw']) - 200) < 1e-7
+    assert abs(
+        float(
+            loads(dumps(o)).output_map(structure=structure, vasp=a)['encutgw'])
+        - 200) < 1e-8
+    assert abs(eval(repr(o), d).value - 200 * eV) < 1e-6
     assert abs(loads(dumps(o)).value - 200 * eV) < 1e-8
     assert eval(repr(o), d).value.units == hartree
     assert loads(dumps(o)).value.units == hartree
+
 
 if __name__ == "__main__":
     from sys import argv


### PR DESCRIPTION
Not sure how or why, but should correct #22 for OS-X

Also, code formatter got the best of me. This PR only modifies one line for CMakeCache.txt vars in setup.py.