### PR TITLE
Seperated write_potcar into its own function

### DIFF
--- a/src/pylada/vasp/functional.py
+++ b/src/pylada/vasp/functional.py
@@ -1017,9 +1017,8 @@ class Vasp(AttrBlock):
             # creates POTCAR file
             logger.debug("vasp/functional bringup: files.POTCAR: %s " % files.POTCAR)
             with open(files.POTCAR, 'w') as potcar:
-                for s in specieset(structure):
-                    outLines = self.species[s].read_potcar()
-                    potcar.writelines(outLines)
+                self.write_potcar(potcar, structure)
+
             # Add is running file marker.
             local_path(outdir).join('.pylada_is_running').ensure(file=True)
             self._copy_additional_files(outdir)
@@ -1115,7 +1114,13 @@ class Vasp(AttrBlock):
                 outLine = "{0[0]} {0[1]} {0[2]} {1}\n".format(
                     kpoint, 1 if len(kpoint) == 3 else kpoint[3])
                 file.write(outLine)
-
+    
+    def write_potcar(self, file, structure):
+        """ Writes the potcar file """
+        for s in specieset(structure):
+            outLines = self.species[s].read_potcar()
+            file.writelines(outLines)
+    
     def __repr__(self, defaults=True, name=None):
         """ Returns representation of this instance """
         from ..tools.uirepr import uirepr

--- a/src/pylada/vasp/functional.py
+++ b/src/pylada/vasp/functional.py
@@ -1117,6 +1117,7 @@ class Vasp(AttrBlock):
     
     def write_potcar(self, file, structure):
         """ Writes the potcar file """
+        from ..crystal import specieset
         for s in specieset(structure):
             outLines = self.species[s].read_potcar()
             file.writelines(outLines)


### PR DESCRIPTION
A very minor modification, moving the potcar writing functionality from inside `bringup` to its own function. 
This A: makes `bringup` a little cleaner, but more importantly B: allows custom functionals to easily modify the potcar writer. 
I'm writing a functional for doing NEB and this would be very helpful, so I don't have to copy-paste all of `bringup`.